### PR TITLE
feat(ui): add configurable font colour with UI theme fallback

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -27,6 +27,12 @@
     <entry name="textweather" type="bool">
       <default>true</default>
       </entry>
+    <entry name="fontColourMode" type="int">
+      <default>0</default>
+    </entry>
+    <entry name="fontColour" type="string">
+      <default></default>
+    </entry>
   </group>
 
 </kcfg>

--- a/contents/ui/CompactRepresentation.qml
+++ b/contents/ui/CompactRepresentation.qml
@@ -20,6 +20,9 @@ Item {
     property bool activeweathershottext: heightH > 34
     property int fonssizes: Plasmoid.configuration.sizeFontConfig
     property int heightH: root.height
+    property int fontColourMode: Plasmoid.configuration.fontColourMode
+    property string fontColour: Plasmoid.configuration.fontColour
+    readonly property color effectiveFontColour: (fontColourMode === 1 && fontColour !== "") ? fontColour : PlasmaCore.Theme.textColor
     property var widthWidget: activeweathershottext ? temOfCo.implicitWidth : temOfCo.implicitWidth + wrapper_weathertext.width
     property var widthReal: isVertical ? root.width : initial.implicitWidth
     property var hVerti: wrapper_vertical.implicitHeight
@@ -69,7 +72,7 @@ Item {
                     text: weatherData.temperaturaActual
                     font.bold: boldfonts
                     font.pixelSize: fonssizes
-                    color: PlasmaCore.Theme.textColor
+                    color: effectiveFontColour
                     horizontalAlignment: Text.AlignLeft
                     verticalAlignment: Text.AlignVCenter
                 }
@@ -81,7 +84,7 @@ Item {
                     horizontalAlignment: Text.AlignLeft
                     font.bold: boldfonts
                     font.pixelSize: fonssizes
-                    color: PlasmaCore.Theme.textColor
+                    color: effectiveFontColour
                     verticalAlignment: Text.AlignVCenter
                 }
             }
@@ -95,6 +98,7 @@ Item {
                     text: weatherData.weatherShottext
                     font.pixelSize: fonssizes
                     font.bold: true
+                    color: effectiveFontColour
                     verticalAlignment: Text.AlignVCenter
                 }
             }
@@ -127,7 +131,7 @@ Item {
                 text: weatherData.temperaturaActual
                 font.bold: boldfonts
                 font.pixelSize: fonssizes
-                color: PlasmaCore.Theme.textColor
+                color: effectiveFontColour
                 horizontalAlignment: Text.AlignHCenter
             }
             Label {
@@ -136,7 +140,7 @@ Item {
                 text: (root.temperatureUnit === "0") ? " °C" : " °F"
                 font.bold: boldfonts
                 font.pixelSize: fonssizes
-                color: PlasmaCore.Theme.textColor
+                color: effectiveFontColour
                 horizontalAlignment: Text.AlignHCenter
             }
         }

--- a/contents/ui/FullRepresentation.qml
+++ b/contents/ui/FullRepresentation.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Layouts 1.1
 import org.kde.plasma.plasmoid
 import org.kde.plasma.components 3.0 as PlasmaComponents3
+import org.kde.plasma.core as PlasmaCore
 import "components" as Components
 import org.kde.kirigami as Kirigami
 
@@ -15,6 +16,9 @@ ColumnLayout {
     }
 
     property int temperatureUnit: Plasmoid.configuration.temperatureUnit
+    property int fontColourMode: Plasmoid.configuration.fontColourMode
+    property string fontColour: Plasmoid.configuration.fontColour
+    readonly property color effectiveFontColour: (fontColourMode === 1 && fontColour !== "") ? fontColour : PlasmaCore.Theme.textColor
 
     function sumarDia(a) {
         var currentDay = (new Date()).getDay()
@@ -45,6 +49,7 @@ ColumnLayout {
                 text: temperatureUnit === 0 ? weatherData.temperaturaActual + "°C" : weatherData.temperaturaActual + "°F"
                 width: parent.width
                 font.pixelSize: currentWeather.height * 0.4
+                color: effectiveFontColour
                 horizontalAlignment: Text.AlignHCenter
             }
             PlasmaComponents3.Label {
@@ -52,12 +57,14 @@ ColumnLayout {
                 text: weatherData.weatherLongtext
                 width: parent.width
                 font.pixelSize: currentWeather.height * .18
+                color: effectiveFontColour
                 horizontalAlignment: Text.AlignHCenter
             }
             PlasmaComponents3.Label {
                 text: weatherData.textProbability + ": " + weatherData.probabilidadDeLLuvia + "%"
                 width: parent.width
                 font.pixelSize: currentWeather.height * .09
+                color: effectiveFontColour
                 horizontalAlignment: Text.AlignHCenter
             }
         }
@@ -81,6 +88,7 @@ ColumnLayout {
                 PlasmaComponents3.Label {
                     width: parent.width
                     text: days[sumarDia((modelData + 1))]
+                    color: effectiveFontColour
                     horizontalAlignment: Text.AlignHCenter
                 }
 
@@ -95,11 +103,13 @@ ColumnLayout {
                     PlasmaComponents3.Label {
                         id: max
                         text: modelData === 0 ? Math.round(weatherData.maxweatherTomorrow) + "°  " :  modelData === 1  ? Math.round(weatherData.maxweatherDayAftertomorrow) + "° " : modelData === 2 ? Math.round(weatherData.maxweatherTwoDaysAfterTomorrow) + "°  " : ""
+                        color: effectiveFontColour
                         horizontalAlignment: Text.AlignHCenter
                     }
                     PlasmaComponents3.Label {
                         id: min
                         text:  modelData === 0 ? Math.round(weatherData.minweatherTomorrow) + "°" :  modelData === 1  ? Math.round(weatherData.minweatherDayAftertomorrow) + "°" : modelData === 2 ? Math.round(weatherData.minweatherTwoDaysAfterTomorrow) + "°" : ""
+                        color: effectiveFontColour
                         opacity: .5
                         horizontalAlignment: Text.AlignHCenter
                     }

--- a/contents/ui/GeneralConfig.qml
+++ b/contents/ui/GeneralConfig.qml
@@ -16,6 +16,11 @@ Item {
         property var value
     }
 
+    QtObject {
+        id: fontColourModeValue
+        property var value
+    }
+
     signal configurationChanged
 
     property alias cfg_temperatureUnit: unidWeatherValue.value
@@ -25,6 +30,8 @@ Item {
     property alias cfg_useCoordinatesIp: autamateCoorde.checked
     property alias cfg_boldfonts: boldfont.checked
     property alias cfg_textweather: textweather.checked
+    property alias cfg_fontColourMode: fontColourModeValue.value
+    property alias cfg_fontColour: fontColourInput.text
 
     Kirigami.FormLayout {
         width: parent.width
@@ -87,6 +94,25 @@ Item {
             ]
             onActivated: fontsizeValue.value = currentValue
             Component.onCompleted: currentIndex = indexOfValue(fontsizeValue.value)
+        }
+        ComboBox {
+            textRole: "text"
+            valueRole: "value"
+            id: fontColourModeBox
+            Kirigami.FormData.label: i18n("Font Colour:")
+            model: [
+                {text: i18n("UI Theme"), value: 0},
+                {text: i18n("Custom"), value: 1},
+            ]
+            onActivated: fontColourModeValue.value = currentValue
+            Component.onCompleted: currentIndex = indexOfValue(fontColourModeValue.value)
+        }
+        TextField {
+            id: fontColourInput
+            visible: fontColourModeBox.currentValue === 1
+            Kirigami.FormData.label: i18n("Colour (HTML):")
+            placeholderText: "#ffffff"
+            width: 200
         }
     }
 


### PR DESCRIPTION
Heya!

My UI theme settings made it so the app was placing a dark font colour onto my dark taskbars, so Iv implemented the option to change from the UI-matching default to any html colour. Iv made it to change not just the compact representation but the full one as well, as I thought someone might like to have a fancy colour in their setup. More technical notes below. This is fully backward compatible, users who don't touch the setting will never notice a change.


```
Changes

  contents/config/main.xml
  Two new config entries are added to the General group:
  - fontColourMode (int, default 0) — tracks whether the user has selected UI Theme (0) or Custom (1)
  - fontColour (string, default "") — stores the user-supplied HTML colour value

  contents/ui/GeneralConfig.qml
  A new Font Colour section is appended to the settings form, following the existing field conventions:
  - A ComboBox presenting "UI Theme" and "Custom" options, wired through a QtObject to persist the
  selection
  - A TextField that appears only when "Custom" is selected, with a placeholderText of #ffffff to
  communicate the expected input format. Width matches the existing Latitude/Longitude fields.

  contents/ui/CompactRepresentation.qml
  Three properties are added at the top of the item:
  property int fontColourMode: Plasmoid.configuration.fontColourMode
  property string fontColour: Plasmoid.configuration.fontColour
  readonly property color effectiveFontColour: (fontColourMode === 1 && fontColour !== "") ? fontColour :
   PlasmaCore.Theme.textColor
  All 5 labels (temperature value, unit suffix, and short weather description — in both horizontal and
  vertical panel orientations) are updated from PlasmaCore.Theme.textColor or no explicit colour to
  effectiveFontColour.

  contents/ui/FullRepresentation.qml
  The same three properties and resolution logic are added. A previously missing import
  org.kde.plasma.core as PlasmaCore is also added, which was required for the theme colour fallback. All
  6 labels in the expanded popup view are updated: current temperature, long weather description, rain
  probability, forecast day names, and forecast max/min temperatures. The existing opacity: .5 on the
  minimum temperature label is preserved.

Behaviour

  - With "UI Theme" selected (default), all labels behave exactly as before — no visual change for
  existing users.
  - With "Custom" selected and a valid HTML colour entered, all visible text across both the compact
  panel view and the expanded popup adopts that colour reactively, without requiring a widget restart.
  - If "Custom" is selected but the field is left empty, the widget silently falls back to the theme
  colour.
```
